### PR TITLE
Create databases when a list is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Default port used by the daemon.
 
 The IP address that the service should listen on.
 
+    couchdb_databases: []
+
+List of databases to create.
+
+    couchdb_delete_existing_databases: false
+
+Whether databases defined using ``couchdb_databases`` should be deleted if they exist. This is most likey only useful in development environments where you may want to remove existing data and start from scratch.
+
     couchdb_enable_automatic_compaction: true
 
 Whether the database(s) should be compacted.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,12 @@ couchdb_port: '5984'
 # Used in templates/local.ini.j2
 couchdb_host_address: '0.0.0.0'
 
+# List of databases to create
+couchdb_databases: []
+
+# Delete existing databases
+couchdb_delete_existing_databases: false
+
 # Used in templates/local.ini.j2
 couchdb_enable_automatic_compaction: true
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,3 +1,4 @@
+---
 - name: Ensure the couchdb group exists
   group:
     name: "{{ couchdb_groupname }}"

--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -1,3 +1,4 @@
+---
 - name: Ensure /etc/couchdb/local.ini exists
   template:
     src: local.ini.j2
@@ -12,3 +13,20 @@
     name: couchdb
     state: started
     enabled: yes
+
+- name: Delete existing databases if asked to do so
+  uri:
+    url: "http://{{ couchdb_host_address }}:{{ couchdb_port }}/{{ item }}"
+    method: DELETE
+  with_items: "{{ couchdb_databases }}"
+  ignore_errors: yes
+  when: (couchdb_delete_existing_databases) and (couchdb_databases)
+
+- name: Create databases if asked to do so
+  uri:
+    url: "http://{{ couchdb_host_address }}:{{ couchdb_port }}/{{ item }}"
+    method: PUT
+    status_code: 200, 201
+  with_items: "{{ couchdb_databases }}"
+  when: couchdb_databases
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,3 +1,4 @@
+---
 # Workaround for https://github.com/ansible/ansible-modules-extras/issues/471
 - name: Install Yum Utilities
   shell: dnf -y install yum-utils


### PR DESCRIPTION
If a ``couchdb_databases`` list is provided then the role will create those databases. This is part of work that I helped @cindyli and @jobara with. I think it would be more useful if these changes were part of this role rather than random playbooks.